### PR TITLE
Add LED to Examples, update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,17 +30,17 @@ Installing from PyPI
 --------------------
 
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
-PyPI <https://pypi.org/project/adafruit-circuitpython-bme280/>`_. To install for current user:
+PyPI <https://pypi.org/project/adafruit-circuitpython-tinylora/>`_. To install for current user:
 
 .. code-block:: shell
 
-    pip3 install adafruit-circuitpython-bme280
+    pip3 install adafruit-circuitpython-tinylora
 
 To install system-wide (this may be required in some cases):
 
 .. code-block:: shell
 
-    sudo pip3 install adafruit-circuitpython-bme280
+    sudo pip3 install adafruit-circuitpython-tinylora
 
 To install in a virtual environment in your current project:
 
@@ -49,7 +49,7 @@ To install in a virtual environment in your current project:
     mkdir project-name && cd project-name
     python3 -m venv .env
     source .env/bin/activate
-    pip3 install adafruit-circuitpython-bme280
+    pip3 install adafruit-circuitpython-tinylora
 
 Usage Example
 =============

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,31 @@ Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
+Installing from PyPI
+--------------------
+
+On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
+PyPI <https://pypi.org/project/adafruit-circuitpython-bme280/>`_. To install for current user:
+
+.. code-block:: shell
+
+    pip3 install adafruit-circuitpython-bme280
+
+To install system-wide (this may be required in some cases):
+
+.. code-block:: shell
+
+    sudo pip3 install adafruit-circuitpython-bme280
+
+To install in a virtual environment in your current project:
+
+.. code-block:: shell
+
+    mkdir project-name && cd project-name
+    python3 -m venv .env
+    source .env/bin/activate
+    pip3 install adafruit-circuitpython-bme280
+
 Usage Example
 =============
 
@@ -87,3 +112,11 @@ Now, once you have the virtual environment activated:
 This will output the documentation to ``docs/_build/html``. Open the index.html in your browser to
 view them. It will also (due to -W) error out on any warning like Travis will. This is a good way to
 locally verify it will pass.
+
+License
+=======
+This library was written by ClemensRiederer. We've converted it to work with Adafruit CircuitPython and made
+changes so it works with the Raspberry Pi and Adafruit Feather M0/M4. We've added examples for using this library
+to transmit data and sensor data to The Things Network.
+
+This open source code is licensed under the LGPL license (see LICENSE for details).

--- a/examples/tinylora_simpletest.py
+++ b/examples/tinylora_simpletest.py
@@ -4,6 +4,10 @@ import digitalio
 import board
 from adafruit_tinylora.adafruit_tinylora import TTN, TinyLoRa
 
+# Board LED
+led = digitalio.DigitalInOut(board.D13)
+led.direction = digitalio.Direction.OUTPUT
+
 spi = busio.SPI(board.SCK, MISO=board.MISO, MOSI=board.MOSI)
 
 # RFM9x Breakout Pinouts
@@ -34,5 +38,7 @@ while True:
     print('Sending packet...')
     lora.send_data(data, len(data), lora.frame_counter)
     print('Packet sent!')
+    led.value = True
     lora.frame_counter += 1
     time.sleep(1)
+    led.value = False

--- a/examples/tinylora_simpletest_si7021.py
+++ b/examples/tinylora_simpletest_si7021.py
@@ -7,6 +7,9 @@ import board
 import adafruit_si7021
 from adafruit_tinylora.adafruit_tinylora import TTN, TinyLoRa
 
+# Board LED
+led = digitalio.DigitalInOut(board.D13)
+led.direction = digitalio.Direction.OUTPUT
 
 # Create library object using our bus i2c port for si7021
 i2c = busio.I2C(board.SCL, board.SDA)
@@ -61,5 +64,7 @@ while True:
     print('Sending packet...')
     lora.send_data(data, len(data), lora.frame_counter)
     print('Packet Sent!')
+    led.value = True
     lora.frame_counter += 1
     time.sleep(2)
+    led.value = False


### PR DESCRIPTION
Adding a LED blink to signify that a packet is sending/sent to The Things Network.

Updated README to incl. license information and correct PyPi installation instructions. 