### PR TITLE
fixing docs badge, adding link to guide, and removing redundant kwargs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Introduction
 ============
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-tinylora/badge/?version=latest
-    :target: https://circuitpython.readthedocs.io/projects/tinylora/en/latest/
+.. image:: https://readthedocs.org/projects/circuitpython-tinylora/badge/?version=latest
+    :target: https://circuitpython-tinylora.readthedocs.io/en/latest/
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/discord/327254708534116352.svg
@@ -54,7 +54,9 @@ To install in a virtual environment in your current project:
 Usage Example
 =============
 
-Usage example is described in the learn guide for this library.
+Usage is described in the `learn guide for this library<https://learn.adafruit.com/using-lorawan-and-the-things-network-with-circuitpython>`_.
+
+
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Introduction
 ============
 
-.. image:: https://readthedocs.org/projects/circuitpython-tinylora/badge/?version=latest
-    :target: https://circuitpython-tinylora.readthedocs.io/en/latest/
+.. image:: https://readthedocs.org/projects/adafruit-circuitpython-tinylora/badge/?version=latest
+    :target: https://circuitpython.readthedocs.io/projects/tinylora/en/latest/
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/discord/327254708534116352.svg
@@ -23,8 +23,7 @@ This driver depends on:
 * `Bus Device <https://github.com/adafruit/Adafruit_CircuitPython_BusDevice>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
-This is easily achieved by downloading
-`the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
+This is easily achieved by downloading `the Adafruit library and driver bundle <https://github.com/adafruit/Adafruit_CircuitPython_Bundle>`_.
 
 Installing from PyPI
 --------------------
@@ -54,7 +53,7 @@ To install in a virtual environment in your current project:
 Usage Example
 =============
 
-Usage is described in the `learn guide for this library<https://learn.adafruit.com/using-lorawan-and-the-things-network-with-circuitpython>`_.
+Usage is described in the `learn guide for this library <https://learn.adafruit.com/using-lorawan-and-the-things-network-with-circuitpython>`_.
 
 
 

--- a/examples/tinylora_simpletest.py
+++ b/examples/tinylora_simpletest.py
@@ -8,7 +8,7 @@ from adafruit_tinylora.adafruit_tinylora import TTN, TinyLoRa
 led = digitalio.DigitalInOut(board.D13)
 led.direction = digitalio.Direction.OUTPUT
 
-spi = busio.SPI(board.SCK, MISO=board.MISO, MOSI=board.MOSI)
+spi = busio.SPI(board.SCK, board.MISO, board.MOSI)
 
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)

--- a/examples/tinylora_simpletest_si7021.py
+++ b/examples/tinylora_simpletest_si7021.py
@@ -16,7 +16,7 @@ i2c = busio.I2C(board.SCL, board.SDA)
 sensor = adafruit_si7021.SI7021(i2c)
 
 # Create library object using our bus SPI port for radio
-spi = busio.SPI(board.SCK, MISO=board.MISO, MOSI=board.MOSI)
+spi = busio.SPI(board.SCK, board.MISO, board.MOSI)
 
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)


### PR DESCRIPTION
Fix issue with the Readme RTD badge not pointing correctly.

Add link to guide (publishing soon) to README.

Remove redundant kwargs from spi object init. 

