### PR TITLE
Fix SPI Line Ordering in Examples

### DIFF
--- a/examples/tinylora_simpletest.py
+++ b/examples/tinylora_simpletest.py
@@ -8,7 +8,7 @@ from adafruit_tinylora.adafruit_tinylora import TTN, TinyLoRa
 led = digitalio.DigitalInOut(board.D13)
 led.direction = digitalio.Direction.OUTPUT
 
-spi = busio.SPI(board.SCK, board.MISO, board.MOSI)
+spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)

--- a/examples/tinylora_simpletest_si7021.py
+++ b/examples/tinylora_simpletest_si7021.py
@@ -16,7 +16,7 @@ i2c = busio.I2C(board.SCL, board.SDA)
 sensor = adafruit_si7021.SI7021(i2c)
 
 # Create library object using our bus SPI port for radio
-spi = busio.SPI(board.SCK, board.MISO, board.MOSI)
+spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)


### PR DESCRIPTION
Change:
`spi = busio.SPI(board.SCK, board.MISO, board.MOSI)` to correct ordering
`spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)` in both examples.
