### PR TITLE
Add explicit pin directions to examples

### DIFF
--- a/adafruit_tinylora/adafruit_tinylora.py
+++ b/adafruit_tinylora/adafruit_tinylora.py
@@ -138,8 +138,11 @@ class TinyLoRa:
         :param int channel: Frequency Channel.
         """
         self._irq = irq
+        self._irq.switch_to_input()
+        self._cs = cs
+        self._cs.switch_to_output()
         # Set up SPI Device on Mode 0
-        self._device = adafruit_bus_device.spi_device.SPIDevice(spi, cs, baudrate=4000000,
+        self._device = adafruit_bus_device.spi_device.SPIDevice(spi, self._cs, baudrate=4000000,
                                                                 polarity=0, phase=0)
         # Verify the version of the RFM module
         self._version = self._read_u8(_REG_VERSION)

--- a/examples/tinylora_simpletest.py
+++ b/examples/tinylora_simpletest.py
@@ -12,7 +12,9 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)
+cs.direction = digitalio.Direction.INPUT
 irq = digitalio.DigitalInOut(board.D6)
+irq.direction = digitalio.Direction.INPUT
 
 # Feather M0 RFM9x Pinouts
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)

--- a/examples/tinylora_simpletest.py
+++ b/examples/tinylora_simpletest.py
@@ -19,6 +19,10 @@ irq.direction = digitalio.Direction.INPUT
 # Feather M0 RFM9x Pinouts
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
+# cs = digitalio.DigitalInOut(board.RFM9X_CS)
+# cs.direction = digitalio.Direction.INPUT
+# irq = digitalio.DigitalInOut(board.RFM9X_D0)
+# irq.direction = digitalio.Direction.INPUT
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])

--- a/examples/tinylora_simpletest.py
+++ b/examples/tinylora_simpletest.py
@@ -12,17 +12,11 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)
-cs.direction = digitalio.Direction.INPUT
 irq = digitalio.DigitalInOut(board.D6)
-irq.direction = digitalio.Direction.INPUT
 
 # Feather M0 RFM9x Pinouts
-# irq = digitalio.DigitalInOut(board.RFM9X_D0)
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
-# cs = digitalio.DigitalInOut(board.RFM9X_CS)
-# cs.direction = digitalio.Direction.INPUT
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)
-# irq.direction = digitalio.Direction.INPUT
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])

--- a/examples/tinylora_simpletest_si7021.py
+++ b/examples/tinylora_simpletest_si7021.py
@@ -20,15 +20,11 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)
-cs.direction = digitalio.Direction.INPUT
 irq = digitalio.DigitalInOut(board.D6)
-irq.direction = digitalio.Direction.INPUT
 
 # Feather M0 RFM9x Pinouts
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
-# cs.direction = digitalio.Direction.INPUT
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)
-# irq.direction = digitalio.Direction.INPUT
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])

--- a/examples/tinylora_simpletest_si7021.py
+++ b/examples/tinylora_simpletest_si7021.py
@@ -25,8 +25,10 @@ irq = digitalio.DigitalInOut(board.D6)
 irq.direction = digitalio.Direction.INPUT
 
 # Feather M0 RFM9x Pinouts
-# irq = digitalio.DigitalInOut(board.RFM9X_D0)
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
+# cs.direction = digitalio.Direction.INPUT
+# irq = digitalio.DigitalInOut(board.RFM9X_D0)
+# irq.direction = digitalio.Direction.INPUT
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])

--- a/examples/tinylora_simpletest_si7021.py
+++ b/examples/tinylora_simpletest_si7021.py
@@ -20,7 +20,9 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)
+cs.direction = digitalio.Direction.INPUT
 irq = digitalio.DigitalInOut(board.D6)
+irq.direction = digitalio.Direction.INPUT
 
 # Feather M0 RFM9x Pinouts
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)


### PR DESCRIPTION
While digitalio defaults to input, it's very important for the `IRQ` and `CS` pins to be set as inputs, IRQ is expected to be pulled up at the end of the `send_packet()` method. 

Patch: 
* Adding explicit pin directions to examples in case the default changes and for clarity.