### PR TITLE
adding example for single-channel sends

### DIFF
--- a/examples/tinylora_simpletest_single_channel.py
+++ b/examples/tinylora_simpletest_single_channel.py
@@ -1,0 +1,45 @@
+import time
+import busio
+import digitalio
+import board
+from adafruit_tinylora.adafruit_tinylora import TTN, TinyLoRa
+
+# Board LED
+led = digitalio.DigitalInOut(board.D13)
+led.direction = digitalio.Direction.OUTPUT
+
+spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+
+# RFM9x Breakout Pinouts
+cs = digitalio.DigitalInOut(board.D5)
+irq = digitalio.DigitalInOut(board.D6)
+
+# Feather M0 RFM9x Pinouts
+# cs = digitalio.DigitalInOut(board.RFM9X_CS)
+# irq = digitalio.DigitalInOut(board.RFM9X_D0)
+
+# TTN Device Address, 4 Bytes, MSB
+devaddr = bytearray([0x00, 0x00, 0x00, 0x00])
+
+# TTN Network Key, 16 Bytes, MSB
+nwkey = bytearray([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+
+# TTN Application Key, 16 Bytess, MSB
+app = bytearray([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+
+ttn_config = TTN(devaddr, nwkey, app, country='US')
+
+# Broadcasting on channel 0 in US Region - 903.9 MHz
+lora = TinyLoRa(spi, cs, irq, ttn_config, channel=0)
+
+while True:
+    data = bytearray(b"\x43\x57\x54\x46")
+    print('Sending packet...')
+    lora.send_data(data, len(data), lora.frame_counter)
+    print('Packet sent!')
+    led.value = True
+    lora.frame_counter += 1
+    time.sleep(1)
+    led.value = False


### PR DESCRIPTION
Adding a usage example for sending a packet on a single channel, useful for people operating single-channel gateways and debugging. 

Test Info:
TX on Feather M4 w/RFM9x Breakout, Channel 0
RX on Things Network Gateway, Channel 0 RX'd 