### PR TITLE
remove printing of MSB, LSB, MID when a single channel is set

### DIFF
--- a/adafruit_tinylora/adafruit_tinylora.py
+++ b/adafruit_tinylora/adafruit_tinylora.py
@@ -292,9 +292,6 @@ class TinyLoRa:
         :param int channel: Transmit Channel (0 through 7).
         """
         self._rfm_msb, self._rfm_mid, self._rfm_lsb = self._frequencies[channel]
-        print(self._rfm_msb)
-        print(self._rfm_mid)
-        print(self._rfm_lsb)
 
     def _read_into(self, address, buf, length=None):
         """Read a number of bytes from the specified address into the

--- a/adafruit_tinylora/adafruit_tinylora.py
+++ b/adafruit_tinylora/adafruit_tinylora.py
@@ -288,7 +288,7 @@ class TinyLoRa:
             raise KeyError("Invalid or Unsupported Datarate.")
 
     def set_channel(self, channel):
-        """Returns the RFM Channel (if single-channel)
+        """Sets the RFM Channel (if single-channel)
         :param int channel: Transmit Channel (0 through 7).
         """
         self._rfm_msb, self._rfm_mid, self._rfm_lsb = self._frequencies[channel]


### PR DESCRIPTION
Remove the debug `print`s from the `set_channel` method, which would display the `msb`, `lsb` and `mid` frequency values.

For example,`lora = TinyLoRa(spi, cs, irq, ttn_config, channel = 6)` would print:
> 226
> 70
> 140

I'd like to remove the register prints. 