### PR TITLE
Add reset parameter

### DIFF
--- a/examples/tinylora_simpletest.py
+++ b/examples/tinylora_simpletest.py
@@ -13,10 +13,12 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)
 irq = digitalio.DigitalInOut(board.D6)
+rst = digitalio.DigitalInOut(board.D4)
 
 # Feather M0 RFM9x Pinouts
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)
+# rst = digitalio.DigitalInOut(board.RFM9x_RST)
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])
@@ -31,7 +33,7 @@ app = bytearray([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 ttn_config = TTN(devaddr, nwkey, app, country='US')
 
-lora = TinyLoRa(spi, cs, irq, ttn_config)
+lora = TinyLoRa(spi, cs, irq, rst, ttn_config)
 
 while True:
     data = bytearray(b"\x43\x57\x54\x46")

--- a/examples/tinylora_simpletest_si7021.py
+++ b/examples/tinylora_simpletest_si7021.py
@@ -21,10 +21,12 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)
 irq = digitalio.DigitalInOut(board.D6)
+rst = digitalio.DigitalInOut(board.D4)
 
 # Feather M0 RFM9x Pinouts
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)
+# rst = digitalio.DigitalInOut(board.RFM9x_RST)
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])
@@ -39,7 +41,7 @@ app = bytearray([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 ttn_config = TTN(devaddr, nwkey, app, country='US')
 
-lora = TinyLoRa(spi, cs, irq, ttn_config)
+lora = TinyLoRa(spi, cs, irq, rst, ttn_config)
 
 # Data Packet to send to TTN
 data = bytearray(4)

--- a/examples/tinylora_simpletest_single_channel.py
+++ b/examples/tinylora_simpletest_single_channel.py
@@ -13,10 +13,12 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 # RFM9x Breakout Pinouts
 cs = digitalio.DigitalInOut(board.D5)
 irq = digitalio.DigitalInOut(board.D6)
+rst = digitalio.DigitalInOut(board.D4)
 
 # Feather M0 RFM9x Pinouts
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)
+# rst = digitalio.DigitalInOut(board.RFM9x_RST)
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])
@@ -32,7 +34,7 @@ app = bytearray([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ttn_config = TTN(devaddr, nwkey, app, country='US')
 
 # Broadcasting on channel 0 in US Region - 903.9 MHz
-lora = TinyLoRa(spi, cs, irq, ttn_config, channel=0)
+lora = TinyLoRa(spi, cs, irq, rst, ttn_config, channel=0)
 
 while True:
     data = bytearray(b"\x43\x57\x54\x46")


### PR DESCRIPTION
- Resets the RFM9x module before attempting to read the RFM9x `RegVersion`. Prevents chip from starting/reading from a bad state.
- Adds a `deinit()` method along with enter and exit methods for use with a context manager 
- Examples have been changed to reflect the addition of the RST pin.
- Formatted file with Black

Tested on a Feather M4 with Radio FeatherWing.
Test Harness for setting up (and tearing down) the SPI interface and `lora` object:
```
import time
import busio
import digitalio
import board
from adafruit_tinylora.adafruit_tinylora import TTN, TinyLoRa

# RFM9x Breakout Pinouts
cs = digitalio.DigitalInOut(board.D6) 
irq = digitalio.DigitalInOut(board.D5) 
rst = digitalio.DigitalInOut(board.D4)

# TTN Device Address, 4 Bytes, MSB
devaddr = bytearray([snip])

# TTN Network Key, 16 Bytes, MSB
nwkey = bytearray([snip])

# TTN Application Key, 16 Bytess, MSB
app = bytearray([snip])

ttn_config = TTN(devaddr, nwkey, app, country='US')

for i in range(0, 1001):
    print('init RFM9x and TinyLora...', i)
    spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
    lora = TinyLoRa(spi, cs, irq, rst, ttn_config)
    print('Sending Packet...')
    data = bytearray(b"\x43\x57\x54\x46")
    lora.send_data(data, len(data), lora.frame_counter)
    print('Packet Sent!')
    print('tearing down TinyLoRa..')
    lora.deinit()
    print('tearing down SPI..')
    spi.deinit()
```

Test Output (snipped):
```
init RFM9x and TinyLora... 329
Sending Packet...
Packet Sent!
tearing down TinyLoRa..
tearing down SPI..
init RFM9x and TinyLora... 330
Sending Packet...
```