### PR TITLE
changed board.RFM9x_RST to board.RFM9X_RST

### DIFF
--- a/examples/tinylora_simpletest.py
+++ b/examples/tinylora_simpletest.py
@@ -18,7 +18,7 @@ rst = digitalio.DigitalInOut(board.D4)
 # Feather M0 RFM9x Pinouts
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)
-# rst = digitalio.DigitalInOut(board.RFM9x_RST)
+# rst = digitalio.DigitalInOut(board.RFM9X_RST)
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])

--- a/examples/tinylora_simpletest_si7021.py
+++ b/examples/tinylora_simpletest_si7021.py
@@ -26,7 +26,7 @@ rst = digitalio.DigitalInOut(board.D4)
 # Feather M0 RFM9x Pinouts
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)
-# rst = digitalio.DigitalInOut(board.RFM9x_RST)
+# rst = digitalio.DigitalInOut(board.RFM9X_RST)
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])

--- a/examples/tinylora_simpletest_single_channel.py
+++ b/examples/tinylora_simpletest_single_channel.py
@@ -18,7 +18,7 @@ rst = digitalio.DigitalInOut(board.D4)
 # Feather M0 RFM9x Pinouts
 # cs = digitalio.DigitalInOut(board.RFM9X_CS)
 # irq = digitalio.DigitalInOut(board.RFM9X_D0)
-# rst = digitalio.DigitalInOut(board.RFM9x_RST)
+# rst = digitalio.DigitalInOut(board.RFM9X_RST)
 
 # TTN Device Address, 4 Bytes, MSB
 devaddr = bytearray([0x00, 0x00, 0x00, 0x00])


### PR DESCRIPTION
The 'x' was lowercase it should be upper.
>>> import board
>>> dir(board)
['A0', 'A1', 'A2', 'A3', 'A4', 'A5', 'BATTERY', 'D0', 'D1', 'D10', 'D11', 'D12', 'D13', 'D5', 'D6', 'D9', 'I2C', 'MISO', 'MOSI', 'RFM9X_CS', 'RFM9X_D0', 'RFM9X_RST', 'RX', 'SCK', 'SCL', 'SDA', 'SPI', 'TX', 'UART', 'VOLTAGE_MONITOR']
