### PR TITLE
TTN frequency plan support China 470(uplink).

### DIFF
--- a/adafruit_tinylora/adafruit_tinylora.py
+++ b/adafruit_tinylora/adafruit_tinylora.py
@@ -186,6 +186,10 @@ class TinyLoRa:
             from adafruit_tinylora.ttn_eu import TTN_FREQS
 
             self._frequencies = TTN_FREQS
+        elif ttn_config.country == "CN":
+            from adafruit_tinylora.ttn_cn import TTN_FREQS
+
+            self._frequencies = TTN_FREQS
         else:
             raise TypeError("Country Code Incorrect/Unsupported")
         # pylint: enable=import-outside-toplevel

--- a/adafruit_tinylora/ttn_cn.py
+++ b/adafruit_tinylora/ttn_cn.py
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 #
 # Copyright (c) 2018 Brent Rubell for Adafruit
+# Modified by IAMLIUBO, 2021
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/adafruit_tinylora/ttn_cn.py
+++ b/adafruit_tinylora/ttn_cn.py
@@ -1,0 +1,37 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Brent Rubell for Adafruit
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`ttn_cn.py`
+======================================================
+The Things Network Frequency Plans - CN470
+* Author(s): IAMLIUBO
+"""
+TTN_FREQS = {
+    0: (0x79, 0x93, 0x33),  # 486.3 MHz
+    1: (0x79, 0xA0, 0x00),  # 486.5 MHz
+    2: (0x79, 0xAC, 0xCC),  # 486.7 MHz
+    3: (0x79, 0xB9, 0x99),  # 486.9 MHz
+    4: (0x79, 0xC6, 0x66),  # 487.1 MHz
+    5: (0x79, 0xD3, 0x33),  # 487.3 MHz
+    6: (0x79, 0xE0, 0x00),  # 487.5 MHz
+    7: (0x79, 0xEC, 0xCC),
+}  # 487.7 MHz

--- a/adafruit_tinylora/ttn_cn.py
+++ b/adafruit_tinylora/ttn_cn.py
@@ -1,25 +1,8 @@
-# The MIT License (MIT)
+# SPDX-FileCopyrightText: 2018 Brent Rubell for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 IAMLIUBO
 #
-# Copyright (c) 2018 Brent Rubell for Adafruit
-# Modified by IAMLIUBO, 2021
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+# SPDX-License-Identifier: MIT
+
 """
 `ttn_cn.py`
 ======================================================


### PR DESCRIPTION
Calculated based on this [link](https://www.thethingsnetwork.org/docs/lorawan/frequency-plans.html#cn470-510), I have tested it and it can be used normally in China.

Fix codestyle check faild. :)