### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_tinylora/adafruit_tinylora.py
+++ b/adafruit_tinylora/adafruit_tinylora.py
@@ -110,7 +110,7 @@ class TinyLoRa:
     # SPI Write Buffer
     _BUFFER = bytearray(2)
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,invalid-name
     def __init__(self, spi, cs, irq, rst, ttn_config, channel=None):
         """Interface for a HopeRF RFM95/6/7/8(w) radio module. Sets module up for sending to
         The Things Network.


### PR DESCRIPTION
Fixes the following `pylint` errors:

```
************* Module adafruit_tinylora.adafruit_tinylora
Error: adafruit_tinylora/adafruit_tinylora.py:114:28: C0103: Argument name "cs" doesn't conform to '(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$' pattern (invalid-name)
```