### PR TITLE
Issue47/fix short name errors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -219,6 +219,9 @@ indent-after-paren=4
 # tab).
 indent-string='    '
 
+# Names that are allowed even though they violate standard naming conventions.
+good-names=cs
+
 # Maximum number of characters on a single line.
 max-line-length=100
 

--- a/adafruit_tinylora/adafruit_tinylora.py
+++ b/adafruit_tinylora/adafruit_tinylora.py
@@ -297,8 +297,8 @@ class TinyLoRa:
         ):
             self._write_u8(pair[0], pair[1])
         # fill the FIFO buffer with the LoRa payload
-        for k in range(packet_length):
-            self._write_u8(0x00, lora_packet[k])
+        for packet_index in range(packet_length):
+            self._write_u8(0x00, lora_packet[packet_index])
         # switch RFM to TX operating mode
         self._write_u8(_REG_OPERATING_MODE, _MODE_TX)
         # wait for TxDone IRQ, poll for timeout.


### PR DESCRIPTION
Addresses issue #47, library uses short argument names. The fix is in two parts - identifying short var names that are acceptable and adding them to `.pylintrc`, and lengthening short var names that are not acceptable. 

There are some questionable member variables remaining of the form `_ab`. Pylint passes these since the underscore counts as a character. Talked to @kattni and decided that these are ok even if they violate the spirit of the law.

Picked up at PyCon2023 sprints.